### PR TITLE
Use zotero-docling consistently for plugin self-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Then install the `.xpi` via **Tools → Plugins** as above.
 
 ## Usage
 
-1. **Settings**: open Zotero → **Settings → Zotero Docling**.
+1. **Settings**: open Zotero → **Settings → zotero-docling**.
 2. Verify the server URL (default `http://localhost:5001`) and click **Test
    Connection** — it should turn green.
 3. Right-click a PDF (or parent item) in your library → **Convert with

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -1,3 +1,3 @@
 menuitem-convert = Convert with Docling
 menuitem-reconvert = Re-convert with Docling (replace)
-pref-pane-label = Zotero Docling
+pref-pane-label = zotero-docling

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -63,8 +63,8 @@ pref-advanced-title = Advanced
 pref-advanced-help = JSON object whose keys are sent as additional form fields to docling-serve. Overrides anything above. Leave empty to disable.
 
 pref-reset = Reset to defaults
-pref-reset-help = Reverts every Zotero Docling preference (including Server URL) to its built-in default.
-pref-reset-confirm-title = Reset Zotero Docling preferences?
+pref-reset-help = Reverts every zotero-docling preference (including Server URL) to its built-in default.
+pref-reset-confirm-title = Reset zotero-docling preferences?
 pref-reset-confirm-body = This reverts every plugin preference (Server URL, auto-convert, pipeline, VLM preset, output, etc.) to its built-in default. Your Zotero library and existing markdown attachments are not touched.
 pref-reset-done = Preferences reset to defaults
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.0",
   "description": "Convert Zotero PDF attachments to structured markdown via Docling",
   "config": {
-    "addonName": "Zotero Docling",
+    "addonName": "zotero-docling",
     "addonID": "zotero-docling@max3925vats",
     "addonRef": "zoteroDocling",
     "addonInstance": "ZoteroDocling",

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -115,7 +115,7 @@ function bindResetButton(win: Window): void {
   btn.addEventListener("command", () => {
     const Services = (globalThis as any).Services;
     const title =
-      "Reset Zotero Docling preferences?"; /* fluent doesn't resolve here */
+      "Reset zotero-docling preferences?"; /* fluent doesn't resolve here */
     const body =
       "This reverts every plugin preference (Server URL, auto-convert, pipeline, VLM preset, output, etc.) to its built-in default. Your Zotero library and existing markdown attachments are not touched.";
     const confirmed = Services?.prompt?.confirm?.(win, title, body) ?? true;
@@ -138,7 +138,7 @@ function bindResetButton(win: Window): void {
     // ProgressWindow toast for confirmation
     try {
       const pw = new Zotero.ProgressWindow({ closeOnClick: true });
-      pw.changeHeadline("Zotero Docling");
+      pw.changeHeadline("zotero-docling");
       pw.addDescription("Preferences reset to defaults");
       pw.show();
       setTimeout(() => {


### PR DESCRIPTION
Standardises the plugin display name to match the repo/npm name.

## What changed

- `package.json` `addonName`: "Zotero Docling" → "zotero-docling"
- Prefs pane sidebar label
- Reset-to-defaults button confirm dialog title + post-reset toast headline
- README prose reference to the Settings pane

## What stayed the same

- Right-click menu items ("Convert with Docling", "Re-convert with Docling (replace)")
- Toast namespaces during conversion ("Docling: converting…", "Docling auto-convert")
- Acknowledgments section ("Docling team")

These reference the conversion tool/action, not the plugin name.

## Test before merge

- [ ] Tools → Plugins shows "zotero-docling 0.2.0"
- [ ] Edit → Settings sidebar shows "zotero-docling" (lowercase)
- [ ] Reset-to-defaults confirm dialog and toast both use lowercase
- [ ] Right-click menus unchanged ("Convert with Docling")
- [ ] Progress toasts unchanged ("Docling: converting…")