### PR TITLE
Add community-health files (CONTRIBUTING, SECURITY, issue + PR templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,124 @@
+name: Bug report
+description: Something in the plugin isn't working as expected.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in the sections below — they cover the questions we'd otherwise have to ask in follow-ups.
+
+        **Security issues**: don't use this template. Use [Private Vulnerability Reporting](https://github.com/max3925vats/zotero-docling/security/advisories/new) instead.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+      placeholder: When I right-click a PDF and choose Convert with Docling, the toast shows ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: I expected a .md attachment to appear under the parent item.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal sequence that produces the bug.
+      placeholder: |
+        1. Open Zotero with `npm start` (or installed .xpi)
+        2. Right-click a PDF attachment
+        3. Click "Convert with Docling"
+        4. ...
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: Visible in Tools → Plugins.
+      placeholder: e.g. 0.2.1
+    validations:
+      required: true
+
+  - type: input
+    id: zotero-version
+    attributes:
+      label: Zotero version
+      description: Visible in Zotero → About Zotero.
+      placeholder: e.g. 7.0.11 or 9.0.3
+    validations:
+      required: true
+
+  - type: input
+    id: docling-version
+    attributes:
+      label: docling-serve version
+      description: Run `curl http://localhost:5001/version` (or whatever your server URL is).
+      placeholder: e.g. 1.18.0
+    validations:
+      required: false
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: transport
+    attributes:
+      label: Transport mode
+      description: Settings → Async transport → "Use the async endpoint" checkbox.
+      options:
+        - Sync (default)
+        - Async
+    validations:
+      required: false
+
+  - type: dropdown
+    id: pipeline
+    attributes:
+      label: Pipeline
+      description: Settings → Conversion → Pipeline.
+      options:
+        - Standard
+        - VLM
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Paste the ~20 lines around the failure from either:
+        - Browser Toolbox console (filter for `[zotero-docling]` or `[Docling/`)
+        - Zotero's debug log (Help → Debug Output Logging → View Output)
+        - docling-serve terminal output
+        For long logs, attach as a file instead of pasting.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else?
+      description: Screenshots, sample PDFs (if shareable), workarounds you've tried.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Zotero general usage questions
+    url: https://forums.zotero.org/
+    about: For questions about Zotero itself (not this plugin), the official Zotero Forums are the best place.
+  - name: Docling / docling-serve issues
+    url: https://github.com/docling-project/docling-serve/issues
+    about: If the bug is in the conversion pipeline itself (Docling can't parse a particular PDF, OCR engine fails, etc.), the upstream docling-serve repo is the right place.
+  - name: Security vulnerabilities
+    url: https://github.com/max3925vats/zotero-docling/security/advisories/new
+    about: Report privately via GitHub Security Advisories. Do NOT open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Suggest an improvement or a new capability.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. The more concretely you can describe the underlying need (rather than a specific implementation), the better the chances we land on something useful.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the workflow, pain point, or limitation you're hitting.
+      placeholder: When I import a folder of 50 PDFs, the progress toast doesn't tell me which ones failed until the end.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution (optional)
+      description: If you have an idea, describe it. Otherwise leave blank — the problem alone is enough.
+      placeholder: A persistent "Last conversion batch" view in the prefs pane showing successes/failures.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, or workarounds you currently use.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: How much would this affect your workflow?
+      options:
+        - Nice to have — small quality of life
+        - Useful — would speed up something I do regularly
+        - Blocking — prevents me from using the plugin for my workflow
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else?
+      description: Mock-ups, links to similar features in other tools, related issues, etc.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!--
+Thanks for the PR. Fill in the sections below — they help me review faster
+and give an honest paper trail in the squashed commit message.
+
+If this PR closes an issue, add "Closes #123" anywhere in the description.
+-->
+
+## Summary
+
+<!-- What does this PR do? One paragraph. The "why", not just the "what". -->
+
+## Changes
+
+<!-- Bullet list of what changed, file-by-file if useful. Keep it terse. -->
+
+-
+-
+
+## Test plan
+
+<!-- How you verified the change. Manual steps are fine — there's no test
+suite yet. Be specific enough that I can re-run the same checks. -->
+
+- [ ] `npm run lint:check` passes locally
+- [ ] `npm run build` produces an .xpi without errors
+- [ ] `npx tsc --noEmit` is clean
+- [ ] Manually tested in a dev profile: <fill in what>
+
+## Screenshots / logs (if UI- or behaviour-affecting)
+
+<!-- Before/after screenshots for UI changes. Relevant log lines for
+behavioural changes. -->
+
+## Notes for the reviewer
+
+<!-- Anything I should pay extra attention to, known limitations of the
+approach, open questions, follow-ups you're punting on. -->
+
+---
+
+By submitting this PR I agree my contributions are licensed under
+AGPL-3.0-or-later, matching the project licence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing to zotero-docling
+
+Thanks for your interest. This is a solo-maintained plugin and contributions of any size are welcome — from typo fixes to whole features. The notes below should save you a round-trip on the obvious questions.
+
+## Reporting bugs
+
+Open a [GitHub Issue](https://github.com/max3925vats/zotero-docling/issues) using the **Bug report** template. The template asks for:
+
+- Zotero version (e.g. 7.0.x, 9.0.x)
+- docling-serve version (`curl http://localhost:5001/version`)
+- Operating system
+- Steps to reproduce
+- What you expected vs what happened
+- Any relevant log lines from Zotero's **Help → Debug Output Logging** OR the Browser Toolbox console (filter for `[zotero-docling]` or `[Docling/*]`)
+
+Please **don't** paste large debug logs into the issue body — attach as a file, or paste the relevant ~20 lines around the failure.
+
+## Suggesting features
+
+Open a **Feature request** issue. Frame the underlying need rather than a specific implementation if possible — that gives more room to find the best fit.
+
+For broader discussions about Zotero workflows, the [Zotero Forums](https://forums.zotero.org/) are a better venue than this repo's issues.
+
+## Security issues
+
+Please **do not** report security issues in public issues. Use [GitHub's Private Vulnerability Reporting](https://github.com/max3925vats/zotero-docling/security/advisories/new) — details in [SECURITY.md](SECURITY.md).
+
+## Development setup
+
+```bash
+git clone https://github.com/max3925vats/zotero-docling.git
+cd zotero-docling
+npm install
+cp .env.example .env
+# Then edit .env: set ZOTERO_PLUGIN_ZOTERO_BIN_PATH and
+# ZOTERO_PLUGIN_PROFILE_PATH. Use a dedicated dev profile.
+npm start
+```
+
+`npm start` launches Zotero with the plugin hot-loaded. Save any source file and the scaffold rebuilds + reloads.
+
+### Dev profile
+
+Create a separate Zotero profile for development so you don't risk your real library. Run Zotero with `--ProfileManager` once to make one, then point `ZOTERO_PLUGIN_PROFILE_PATH` at its directory.
+
+### Common gotchas
+
+- **macOS path with spaces**: don't shell-escape with `\ ` in `.env` — dotenv reads it literally. Just write the raw path: `ZOTERO_PLUGIN_PROFILE_PATH=/Users/you/Library/Application Support/Zotero/Profiles/abc.dev`.
+- **HF_TOKEN**: set in your shell before running `docling-serve` so model downloads aren't rate-limited.
+- **Zotero 9 sandbox**: some Web APIs (FormData, Blob, AbortController) aren't bare globals in the plugin sandbox — see `getWebApis()` in `src/modules/convert.ts` for the pattern.
+
+## Code style and checks
+
+Before opening a PR:
+
+```bash
+npm run lint:check    # prettier + eslint (CI enforces this)
+npm run build         # confirms the production .xpi builds
+npx tsc --noEmit      # full typecheck
+```
+
+Or just `npm run lint:fix` to auto-format. CI runs the same checks on every PR.
+
+## Branching and PRs
+
+- Branch from `main`. Use a short descriptive branch name (e.g. `fix-skipifexists`, `add-export-folder`).
+- One logical change per PR. Smaller diffs get reviewed faster.
+- Run the local checks above before pushing.
+- PR title and body: see `.github/PULL_REQUEST_TEMPLATE.md` — it's pre-filled when you open a PR.
+
+### Commit messages
+
+Keep them descriptive and imperative present-tense ("Fix skip on duplicate filename", not "Fixed skipping duplicates"). No rigid prefix convention (no Conventional Commits). Multi-line bodies are welcome for non-trivial changes.
+
+### Tests
+
+There's a minimal `test/` directory from the scaffold. No deep test suite yet. Manual testing in a dev profile is the current bar — describe what you tested in the PR description.
+
+## Project layout
+
+```
+addon/              # static plugin assets (manifest, prefs, FTL locales, XUL)
+src/
+  addon.ts          # singleton holding plugin state
+  hooks.ts          # lifecycle hooks (startup, shutdown, prefs events)
+  index.ts          # entry point
+  modules/
+    convert.ts      # core: read PDF → POST to docling-serve → attach .md
+    menu.ts         # right-click menus + batch orchestration
+    notifier.ts     # auto-convert on PDF import (debounced queue)
+    preferenceScript.ts  # prefs pane dynamic behaviour
+    ui.ts           # ProgressWindow wrappers (incl. blur-aware managed)
+  utils/            # small helpers (concurrency, db lock, frontmatter, …)
+typings/            # scaffold-generated d.ts files (committed)
+```
+
+## License
+
+By contributing, you agree your contributions are licensed under [AGPL-3.0-or-later](LICENSE) — the same as the rest of the project.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Treat fellow contributors and users with respect.
+
+## Acknowledgments
+
+This plugin stands on:
+
+- [Docling](https://github.com/docling-project/docling) — the conversion pipeline
+- [docling-serve](https://github.com/docling-project/docling-serve) — the HTTP wrapper we talk to
+- [zotero-plugin-template](https://github.com/windingwind/zotero-plugin-template) and [zotero-plugin-toolkit](https://github.com/windingwind/zotero-plugin-toolkit) by windingwind — the scaffold and helpers
+- The Zotero team — for an extensible, scriptable reference manager

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Supported versions
+
+This project is in active development and only the **latest published release** is supported. Older versions will not receive backported security fixes — please update before reporting.
+
+| Version        | Supported |
+| -------------- | --------- |
+| latest         | ✅        |
+| anything older | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub Issue for security reports.** Use [GitHub's Private Vulnerability Reporting](https://github.com/max3925vats/zotero-docling/security/advisories/new) to send the report privately. That keeps the details off the public timeline until a fix is available.
+
+If for some reason you cannot use Private Vulnerability Reporting, you can also reach the maintainer by opening a **draft** issue titled "Security: please reach out" without details, and we'll move the conversation to a private channel from there.
+
+### What to include
+
+- A clear description of the issue
+- Steps to reproduce (specific Zotero version, docling-serve version, plugin version, sample input if relevant)
+- The impact you observed (file written outside expected directory, sensitive data leak, etc.)
+- Any mitigations you've found
+
+### What to expect
+
+This plugin is solo-maintained on a best-effort basis. Realistic expectations:
+
+- **Acknowledgement**: within ~1 week of report
+- **Triage and assessment**: within ~2 weeks
+- **Fix and release**: depends on severity and complexity; critical issues prioritised
+
+Reporters will be credited in the release notes unless they prefer to remain anonymous.
+
+## Scope
+
+This plugin runs inside Zotero's plugin sandbox and communicates with a user-configured `docling-serve` HTTP endpoint. In-scope security concerns include:
+
+- **Arbitrary file write outside the intended location** — e.g. a crafted PDF or server response that escapes the temp directory or export folder
+- **Prefs / config injection** — a flaw that lets external content mutate plugin preferences
+- **Server URL handling** — anything that lets a malicious actor redirect conversions to an attacker-controlled server without user consent
+- **Markdown injection that escapes its container** — e.g. content that breaks out of Zotero's storage model or escapes the markdown attachment context
+- **Subprocess / privileged-API abuse** — the plugin does not currently spawn subprocesses, but if it ever does, that surface is in scope
+
+## Out of scope
+
+- **Bugs in [Docling](https://github.com/docling-project/docling) itself** — report those to the [Docling team](https://github.com/docling-project/docling/issues).
+- **Bugs in [docling-serve](https://github.com/docling-project/docling-serve)** — report to [docling-serve's repository](https://github.com/docling-project/docling-serve/issues).
+- **Zotero itself** — report to the [Zotero team](https://www.zotero.org/support/reporting_bugs).
+- **Network-level attacks** when the user has configured a remote `serverUrl` over plain HTTP. The plugin trusts whatever endpoint the user points it at; use HTTPS for non-local servers.
+- **Vulnerabilities that require the attacker to already have access to the user's Zotero profile directory** — at that point the attacker can already do worse things directly.
+
+## A note on AGPL
+
+This project is licensed under [AGPL-3.0-or-later](LICENSE). If you redistribute a modified version of this plugin, you are responsible for the security of your fork. Security fixes from upstream are not automatically applied to forks.


### PR DESCRIPTION
## Summary

Fills in the GitHub Community Standards checklist so the repo presents the standard signals (how to contribute, how to report security issues, what shape a bug report or feature request should take, what shape a PR should take). Documentation-only — no code paths touched.

## Changes

- **\`CONTRIBUTING.md\`** — bug-report and feature-request workflow, dev setup (env, dev profile, common gotchas including the macOS path-with-spaces issue and Z9 sandbox notes), code-style + check expectations, branching and commit conventions, project layout.
- **\`SECURITY.md\`** — supported-versions table, private vulnerability reporting via GitHub Security Advisories, what's in scope (file-write escapes, prefs injection, server-URL handling) vs out-of-scope (Docling/docling-serve/Zotero proper).
- **\`.github/ISSUE_TEMPLATE/bug_report.yml\`** — structured form: plugin/Zotero/docling-serve versions, OS, transport + pipeline dropdowns, repro steps, logs.
- **\`.github/ISSUE_TEMPLATE/feature_request.yml\`** — problem-first format with optional proposal and scope dropdown.
- **\`.github/ISSUE_TEMPLATE/config.yml\`** — disables blank issues; routes Zotero usage Qs to the forums, conversion-pipeline bugs to docling-serve, security to Private Vulnerability Reporting.
- **\`.github/PULL_REQUEST_TEMPLATE.md\`** — summary, changes, test-plan checklist, screenshots/logs section, AGPL acknowledgment.

## Test plan

- [x] \`npm run lint:check\` passes locally
- [x] \`npm run build\` produces an .xpi without errors
- [x] \`npx tsc --noEmit\` is clean
- [ ] Manually tested in a dev profile: N/A — documentation-only change

## Screenshots / logs (if UI- or behaviour-affecting)

Not applicable — no UI or behaviour changes. The new YAML templates will render as GitHub forms on the "New issue" page; will spot-check that after merge.

## Notes for the reviewer

- **Code of Conduct is intentionally not in this PR.** Easiest path is to add it via GitHub's built-in **Insights → Community Standards → Add → Contributor Covenant**, which commits the canonical text directly. Can be done after this PR merges.
- **Private Vulnerability Reporting must be enabled in repo settings** for the SECURITY.md link to work: **Settings → Security → Private vulnerability reporting → Enable**. One-time toggle.
- This PR's body was originally written without using the new template — corrected via \`gh pr edit\` once I noticed. The fact that the corrected body fits cleanly is itself a small test that the template is well-shaped.

---

By submitting this PR I agree my contributions are licensed under
AGPL-3.0-or-later, matching the project licence.