### PR TITLE
Fix race condition in runBatch (#14)

### DIFF
--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -151,6 +151,10 @@ async function runBatch(
   // Only one batch at a time. A second click while a batch is running
   // would otherwise spawn a parallel orchestrator that fights over the
   // shared managed-progress window.
+  //
+  // The flag MUST be set synchronously before the first `await` — otherwise
+  // two rapid clicks both pass the check, both await the preflight, and
+  // both proceed to spawn a batch.
   if (addon.data.batchInFlight) {
     toast(
       "Docling",
@@ -159,14 +163,14 @@ async function runBatch(
     );
     return;
   }
+  addon.data.batchInFlight = true;
 
   // Pre-flight: avoid N×wall-of-error toasts when docling-serve isn't running.
   if (!(await preflightServer())) {
+    addon.data.batchInFlight = false;
     toast("Docling", "docling-serve isn't running — start it and retry", false);
     return;
   }
-
-  addon.data.batchInFlight = true;
 
   const limit = Math.max(
     1,


### PR DESCRIPTION
## Summary

Resolves the race condition described in #14. `runBatch` was setting `addon.data.batchInFlight` only AFTER `await preflightServer()`, so two rapid clicks of "Convert with Docling" could both pass the guard and spawn duplicate batch orchestrators that fought over the shared managed-progress window.

The fix sets the flag synchronously immediately after the guard check, matching the pattern already used by `processPending` in `notifier.ts`. The existing `try { ... } finally { batchInFlight = false; }` block handles the normal cleanup; one extra clear was added on the preflight-failed early return.

## Test plan

- [ ] Click "Convert with Docling" twice within ~200 ms; only one batch should start, the second click should produce the "already running" toast.
- [ ] Stop docling-serve, click "Convert with Docling": preflight-failed toast fires, and a subsequent click while the server is up cleanly starts a new batch (i.e., flag was released).
- [ ] Existing happy-path conversion still works (regression sanity).

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)