### PR TITLE
Clarify updateManagedHeadline body semantics (#16)

### DIFF
--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -110,17 +110,28 @@ export function startManagedProgress(headline: string, body?: string): void {
 }
 
 /**
- * Update the in-flight managed progress headline. Body is optional and
- * appended if provided. Cheap if Zotero is blurred (only updates state).
+ * Update the in-flight managed progress headline. `appendBody`, if provided,
+ * appends a NEW description line to the progress window — it does NOT
+ * replace the previous body. Each call stacks another line. The underlying
+ * `Zotero.ProgressWindow.addDescription` has no replace primitive, so the
+ * additive semantics are surfaced in the parameter name. Cheap if Zotero is
+ * blurred (only updates state).
+ *
+ * If a future caller wants replace semantics (e.g., per-item live progress
+ * in the same line), the right move is to switch to
+ * `Zotero.ProgressWindow.ItemProgress` rather than overload this function.
  */
-export function updateManagedHeadline(headline: string, body?: string): void {
+export function updateManagedHeadline(
+  headline: string,
+  appendBody?: string,
+): void {
   if (!managed) return;
   managed.headline = headline;
-  if (body !== undefined) managed.body = body;
+  if (appendBody !== undefined) managed.body = appendBody;
   if (managed.pw) {
     try {
       managed.pw.changeHeadline(headline);
-      if (body) managed.pw.addDescription(body);
+      if (appendBody) managed.pw.addDescription(appendBody);
     } catch {
       /* progress window already closed */
     }


### PR DESCRIPTION
## Summary

Resolves #16 via the issue's Option A. The function was documented as updating both headline and an optional body, but its implementation appended a new description via `pw.addDescription(body)` rather than replacing. Current callers in `menu.ts` pass only the headline, so this is a dormant foot-gun — but the function name and JSDoc invite future contributors to pass a body, at which point descriptions would stack per poll tick.

This PR:

- Renames the parameter from `body` to `appendBody`.
- Documents the additive semantics explicitly in JSDoc.
- Points future replace-semantics needs at `Zotero.ProgressWindow.ItemProgress` instead of overloading this function.

No behaviour change for current callers.

## Test plan

- [ ] `npm run build` passes.
- [ ] Existing batch progress window behaves identically (live N-of-M counter still updates).
- [ ] Compile-time: any future caller passing `body:` would have to update to `appendBody:`, surfacing the stacking semantics at the call site.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)