### PR TITLE
Confirm before destructive Re-convert action (#20)

### DIFF
--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -46,3 +46,8 @@ pref("attachToItem", true);
 pref("exportFolderPath", "");
 // OS-level notification when a batch finishes, only if Zotero isn't focused.
 pref("notifyOnComplete", false);
+
+// Show a confirmation prompt before the destructive "Re-convert (replace)"
+// menu action. Users can opt out via a "Don't ask again" checkbox in the
+// dialog itself; Reset to defaults restores this.
+pref("confirmReconvert", true);

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -33,7 +33,7 @@ import {
   removeMatchingMdChild,
   findMatchingMdChild,
 } from "../utils/zotero";
-import { getPref } from "../utils/prefs";
+import { getPref, setPref } from "../utils/prefs";
 import { notifyOnBatchComplete } from "../utils/notification";
 import { ConcurrencyLimiter } from "../utils/concurrencyLimiter";
 import { truncateMiddle } from "../utils/format";
@@ -117,6 +117,84 @@ function shouldShowReconvert(): boolean {
 // ---------------------------------------------------------------------------
 
 /**
+ * Show a "Re-convert with Docling?" confirm dialog with a "Don't ask again"
+ * checkbox. Returns true if the user confirmed. The destructive Re-convert
+ * action deletes the existing .md attachment(s); confirming guards against
+ * an accidental click that would cost minutes-to-hours of compute (or API
+ * spend, when paired with a remote LLM API).
+ *
+ * Uses Services.prompt.confirmEx — cross-platform, supports a checkbox
+ * natively. If the user ticks "Don't ask again" and confirms, we flip the
+ * `confirmReconvert` pref off; the Reset-to-defaults button restores it.
+ */
+function confirmReconvertWithUser(count: number): boolean {
+  const Services = (globalThis as any).Services;
+  const prompt = Services?.prompt;
+  if (!prompt?.confirmEx) {
+    // No prompt service available (very unusual). Default to allowing the
+    // action — losing the confirm is preferable to silently blocking the
+    // user from re-converting at all.
+    return true;
+  }
+
+  const Ci = (globalThis as any).Components?.interfaces;
+  const STD =
+    prompt.BUTTON_TITLE_IS_STRING ??
+    Ci?.nsIPromptService?.BUTTON_TITLE_IS_STRING ??
+    127;
+  const CANCEL =
+    prompt.BUTTON_TITLE_CANCEL ??
+    Ci?.nsIPromptService?.BUTTON_TITLE_CANCEL ??
+    2;
+  const POS0 = prompt.BUTTON_POS_0 ?? Ci?.nsIPromptService?.BUTTON_POS_0 ?? 0;
+  const POS1 = prompt.BUTTON_POS_1 ?? Ci?.nsIPromptService?.BUTTON_POS_1 ?? 8;
+  const flags = STD * POS0 + CANCEL * POS1;
+
+  const win =
+    (Zotero as any).getMainWindow?.() ??
+    (Zotero as any).getActiveZoteroPane?.()?.document?.defaultView ??
+    null;
+
+  const title = "Re-convert with Docling?";
+  const body = `This will delete the existing markdown attachment${count === 1 ? "" : "s"} on ${count} selected PDF${count === 1 ? "" : "s"} and run conversion again. Any manual edits to the existing markdown will be lost.`;
+  const checkLabel = "Don't ask again";
+  const check = { value: false };
+
+  let pressed: number;
+  try {
+    pressed = prompt.confirmEx(
+      win,
+      title,
+      body,
+      flags,
+      "Re-convert", // button 0 (left)
+      null, // button 1 — title comes from CANCEL flag
+      null, // button 2 — unused
+      checkLabel,
+      check,
+    );
+  } catch (e) {
+    Zotero.debug(
+      `${LOG} confirmReconvert prompt threw, allowing action: ${(e as Error).message}`,
+    );
+    return true;
+  }
+
+  // Button index 0 is "Re-convert"; 1 is Cancel.
+  if (pressed !== 0) return false;
+  if (check.value) {
+    try {
+      setPref("confirmReconvert", false);
+    } catch (e) {
+      Zotero.debug(
+        `${LOG} confirmReconvert: failed to persist opt-out: ${(e as Error).message}`,
+      );
+    }
+  }
+  return true;
+}
+
+/**
  * Run convertAttachment over a resolved PDF list with parallel concurrency,
  * per-item progress, and aggregated status tags + toast.
  * `force` bypasses the skipIfExists guard and pre-deletes existing .md.
@@ -146,6 +224,14 @@ async function runBatch(
   if (pdfs.length === 0) {
     toast("Docling", "No PDF attachments in selection", false);
     return;
+  }
+
+  // Re-convert is destructive — it deletes existing .md attachments before
+  // running a fresh conversion. Confirm with the user unless they've opted
+  // out via the "Don't ask again" checkbox. Confirm BEFORE setting any
+  // in-flight state so cancelling is a clean no-op.
+  if (opts.force && ((getPref("confirmReconvert") ?? true) as boolean)) {
+    if (!confirmReconvertWithUser(pdfs.length)) return;
   }
 
   // Only one batch at a time. A second click while a batch is running

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -38,6 +38,7 @@ const ALL_PREF_KEYS: ReadonlyArray<string> = [
   "attachToItem",
   "exportFolderPath",
   "notifyOnComplete",
+  "confirmReconvert",
 ];
 
 export function registerPrefsScripts(win: Window): void {

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -30,6 +30,7 @@ declare namespace _ZoteroTypes {
       "attachToItem": boolean;
       "exportFolderPath": string;
       "notifyOnComplete": boolean;
+      "confirmReconvert": boolean;
     };
   }
 }


### PR DESCRIPTION
## Summary

Adds a confirmation dialog before the destructive **Re-convert with Docling (replace)** menu action runs, gated by a new `confirmReconvert` pref (default true). Resolves #20.

Uses `Services.prompt.confirmEx` for a cross-platform native dialog with a built-in "Don't ask again" checkbox. Ticking the checkbox + confirming flips `confirmReconvert` to false; **Reset to defaults** in the prefs pane restores it (the new key was added to `ALL_PREF_KEYS`).

Dialog count text reflects the actual destructive PDF count (after `runBatch` filters out items with no matching `.md`), not the raw selection size — so "Re-convert 1 PDF" stays accurate even when the user selected a parent with one converted PDF and several unconverted siblings.

Confirm fires before `batchInFlight` is set, so cancelling is a clean no-op with no flag to clear.

## Test plan

- [ ] First-run user clicks Re-convert: dialog appears with "Re-convert" / "Cancel" buttons and a "Don't ask again" checkbox.
- [ ] Cancelling: no .md is deleted, no batch starts, the menu stays available.
- [ ] Confirming: batch runs normally and the .md is replaced.
- [ ] Confirming with "Don't ask again" ticked: pref flips to false; subsequent Re-converts skip the dialog.
- [ ] Reset to defaults in the prefs pane re-enables the prompt.
- [ ] Dialog body reads "Re-convert 1 PDF" vs. "Re-convert N PDFs" based on count.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)