### PR TITLE
Docs: install onboarding + first-run nudges (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # zotero-docling
 
+A Zotero 7+/9 plugin that converts PDF attachments to structured Markdown using
+the [Docling](https://github.com/docling-project/docling) document-understanding
+pipeline, and attaches the resulting `.md` file back to the same parent item.
+
 [![Release](https://img.shields.io/github/v/release/max3925vats/zotero-docling?style=flat-square)](https://github.com/max3925vats/zotero-docling/releases/latest)
 [![License](https://img.shields.io/github/license/max3925vats/zotero-docling?style=flat-square)](LICENSE)
 [![Downloads](https://img.shields.io/github/downloads/max3925vats/zotero-docling/total?style=flat-square)](https://github.com/max3925vats/zotero-docling/releases)
@@ -8,10 +12,6 @@
 [![Powered by Docling](https://img.shields.io/badge/Powered%20by-Docling-052FAD?style=flat-square)](https://github.com/docling-project/docling)
 
 ---
-
-A Zotero 7+/9 plugin that converts PDF attachments to structured Markdown using
-the [Docling](https://github.com/docling-project/docling) document-understanding
-pipeline, and attaches the resulting `.md` file back to the same parent item.
 
 Designed for **literature-lake** workflows: structured markdown becomes a clean
 upstream for note apps, RAG pipelines, citation extraction, summarisation,
@@ -51,21 +51,63 @@ literature reviews, and any downstream tool that prefers plain text over PDFs.
 
 ## Install the server (docling-serve)
 
+Pick one of the three paths below — they all yield a `docling-serve` you can
+point the plugin at. Roughly:
+
+| Option        | Best for                                                        | Needs                |
+| ------------- | --------------------------------------------------------------- | -------------------- |
+| **uv**        | You already have a Python toolchain or want the smallest setup. | Python 3.10+, `uv`   |
+| **pipx**      | You already use pipx for isolated CLI tools.                    | Python 3.10+, `pipx` |
+| **Container** | You'd rather not touch Python at all, or want GPU isolation.    | Docker / Podman      |
+
+### Option A — uv (recommended)
+
 ```bash
-# Recommended: install as a uv tool so it lives in its own venv but is on PATH
-uv tool install "docling-serve[ui]"
+uv tool install "docling-serve[ui]"   # one-time install
+docling-serve run                      # leave this terminal open
+```
 
-# Start the server (leave this terminal open while using the plugin)
+### Option B — pipx
+
+```bash
+pipx install "docling-serve[ui]"      # one-time install
 docling-serve run
+```
 
-# Sanity check
+### Option C — container
+
+```bash
+# CPU-only (works on any host)
+docker run -p 5001:5001 \
+  -e DOCLING_SERVE_ENABLE_UI=true \
+  quay.io/docling-project/docling-serve:latest
+
+# CUDA variant for NVIDIA GPUs
+docker run --gpus all -p 5001:5001 \
+  -e DOCLING_SERVE_ENABLE_UI=true \
+  quay.io/docling-project/docling-serve-cu128:latest
+```
+
+### Sanity check (any option)
+
+```bash
 curl http://localhost:5001/health    # → {"status":"ok"}
 ```
 
-Optional: set `HF_TOKEN` so the first model download isn't rate-limited:
+### ⚠️ First conversion downloads model weights
+
+The first time you convert a PDF, `docling-serve` downloads the model files
+from Hugging Face. Expect **2–10 minutes** for the standard pipeline and
+**significantly longer** (multi-GB) for VLM presets. Subsequent conversions
+are fast. The Zotero progress window will appear to hang during the
+download — that's normal.
+
+**Recommended**: set an `HF_TOKEN` before starting the server so the
+download isn't rate-limited:
 
 ```bash
 export HF_TOKEN=hf_yourTokenHere     # get one at https://huggingface.co/settings/tokens
+docling-serve run
 ```
 
 ---
@@ -88,6 +130,11 @@ npm run build       # outputs .scaffold/build/*.xpi
 ```
 
 Then install the `.xpi` via **Tools → Plugins** as above.
+
+> **macOS note**: profile paths that contain spaces (for example
+> `~/Library/Application Support/Zotero/...`) must be written literally in
+> `.env` — **no** backslash escapes. See [`.env.example`](.env.example) for
+> the exact format.
 
 ---
 

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -46,3 +46,12 @@ pref("attachToItem", true);
 pref("exportFolderPath", "");
 // OS-level notification when a batch finishes, only if Zotero isn't focused.
 pref("notifyOnComplete", false);
+
+// First-run onboarding nudge. Flipped to true after the first startup
+// toast fires OR after the first successful Test Connection. Reset to
+// defaults re-arms the nudge.
+pref("firstRunCompleted", false);
+// Last "Test Connection" result; surfaced when the prefs pane opens so a
+// returning user sees the previous state without re-clicking. JSON string:
+// {"ok": bool, "message": str, "at": ISO-8601 timestamp}. Empty when unset.
+pref("lastHealthResult", "");

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,8 +2,9 @@ import { initLocale, getString } from "./utils/locale";
 import { registerMenu, unregisterMenu } from "./modules/menu";
 import { registerNotifier, unregisterNotifier } from "./modules/notifier";
 import { registerPrefsScripts } from "./modules/preferenceScript";
-import { onZoteroBlur, onZoteroFocus } from "./modules/ui";
+import { onZoteroBlur, onZoteroFocus, toast } from "./modules/ui";
 import { createZToolkit } from "./utils/ztoolkit";
+import { getPref, setPref } from "./utils/prefs";
 
 async function onStartup(): Promise<void> {
   await Promise.all([
@@ -22,6 +23,39 @@ async function onStartup(): Promise<void> {
   );
 
   addon.data.initialized = true;
+  maybeShowFirstRunNudge();
+}
+
+/**
+ * Surface a one-time toast pointing the user at the preferences pane.
+ * Fires only on the first startup after install (gated on the
+ * `firstRunCompleted` pref). The flag is also flipped by a successful
+ * Test Connection in the prefs pane, so a user who finds prefs without
+ * the toast still won't see it next time.
+ *
+ * Deferred via setTimeout so the toast doesn't compete with Zotero's
+ * own startup UI noise.
+ */
+function maybeShowFirstRunNudge(): void {
+  try {
+    if ((getPref("firstRunCompleted") ?? false) as boolean) return;
+  } catch {
+    return;
+  }
+  setTimeout(() => {
+    try {
+      toast(
+        "zotero-docling installed",
+        "Open Tools → Settings → zotero-docling to verify your server connection.",
+        true,
+      );
+      setPref("firstRunCompleted", true);
+    } catch (e) {
+      Zotero.debug(
+        `[zotero-docling] first-run nudge failed (non-fatal): ${(e as Error).message}`,
+      );
+    }
+  }, 2500);
 }
 
 async function onMainWindowLoad(win: _ZoteroTypes.MainWindow): Promise<void> {

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -4,7 +4,7 @@
 //   - Preset dropdowns "Custom…" entry → reveal a free-text input
 //   - "Reset to defaults" button → confirm + clear every plugin pref
 
-import { getPref } from "../utils/prefs";
+import { getPref, setPref } from "../utils/prefs";
 import { testServerConnection } from "./convert";
 
 const LOG = "[zotero-docling]";
@@ -38,6 +38,8 @@ const ALL_PREF_KEYS: ReadonlyArray<string> = [
   "attachToItem",
   "exportFolderPath",
   "notifyOnComplete",
+  "firstRunCompleted",
+  "lastHealthResult",
 ];
 
 export function registerPrefsScripts(win: Window): void {
@@ -53,7 +55,28 @@ export function registerPrefsScripts(win: Window): void {
   bindResetButton(win);
 }
 
-/** "Test Connection" button → calls /health, paints status label. */
+/**
+ * Render the saved health result into the status label without firing a
+ * new request. Used on prefs-pane open so a returning user sees the last
+ * known state instead of an empty line.
+ */
+function paintHealthLabel(
+  label: HTMLElement,
+  result: { ok: boolean; message?: string; serverUrl?: string; at?: string },
+): void {
+  const stamp = result.at
+    ? ` (last checked ${result.at.slice(0, 16).replace("T", " ")})`
+    : "";
+  if (result.ok) {
+    label.textContent = `Connected ✓  (${result.serverUrl ?? ""})${stamp}`;
+    label.style.color = "var(--accent-green, #2a8000)";
+  } else {
+    label.textContent = `Cannot connect — ${result.message ?? "unknown"}${stamp}`;
+    label.style.color = "var(--accent-red, #c00)";
+  }
+}
+
+/** "Test Connection" button → calls /health, paints status label + persists. */
 function bindTestConnection(win: Window): void {
   const btn = win.document.getElementById(
     "zotero-docling-test-connection",
@@ -65,21 +88,59 @@ function bindTestConnection(win: Window): void {
     Zotero.debug(`${LOG} prefs: test-connection elements not found`);
     return;
   }
-  btn.addEventListener("command", async () => {
+
+  const runCheck = async (): Promise<void> => {
     const serverUrl =
       ((getPref("serverUrl") as string) ?? "").trim() ||
       "http://localhost:5001";
     label.textContent = "Testing…";
     label.style.color = "";
     const result = await testServerConnection(serverUrl);
-    if (result.ok) {
-      label.textContent = `Connected ✓  (${result.serverUrl})`;
-      label.style.color = "var(--accent-green, #2a8000)";
-    } else {
-      label.textContent = `Cannot connect — ${result.message}`;
-      label.style.color = "var(--accent-red, #c00)";
+    const snapshot = {
+      ok: result.ok,
+      message: result.ok ? "" : result.message,
+      serverUrl: result.ok ? result.serverUrl : serverUrl,
+      at: new Date().toISOString(),
+    };
+    paintHealthLabel(label, snapshot);
+    try {
+      setPref("lastHealthResult", JSON.stringify(snapshot));
+    } catch {
+      /* persistence is nice-to-have */
     }
+    if (result.ok) {
+      // First successful connection completes the onboarding nudge so the
+      // startup toast doesn't keep firing.
+      try {
+        setPref("firstRunCompleted", true);
+      } catch {
+        /* ignore */
+      }
+    }
+  };
+
+  btn.addEventListener("command", () => {
+    void runCheck();
   });
+
+  // Auto-run on first prefs-pane open in this session when there's no saved
+  // result; otherwise paint the saved one so the user has immediate signal.
+  const saved = ((getPref("lastHealthResult") as string) ?? "").trim();
+  if (saved) {
+    try {
+      const parsed = JSON.parse(saved) as {
+        ok: boolean;
+        message?: string;
+        serverUrl?: string;
+        at?: string;
+      };
+      paintHealthLabel(label, parsed);
+    } catch {
+      void runCheck();
+    }
+  } else {
+    void runCheck();
+  }
 }
 
 /** Pipeline radiogroup → show/hide the VLM section. */

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -30,6 +30,8 @@ declare namespace _ZoteroTypes {
       "attachToItem": boolean;
       "exportFolderPath": string;
       "notifyOnComplete": boolean;
+      "firstRunCompleted": boolean;
+      "lastHealthResult": string;
     };
   }
 }


### PR DESCRIPTION
## Summary

Resolves the documentation and in-product onboarding items from #21.

### README
- Lead with the one-line "what it does" above the badges.
- "Install the server" now offers three paths (uv / pipx / container) with a brief recommendation matrix and a CUDA-variant container note.
- New prominent "First conversion downloads model weights" warning calls out the multi-minute HF download. \`HF_TOKEN\` upgraded from "optional" to "recommended" in the same block.
- macOS-with-spaces footgun callout in the From-source section, pointing at \`.env.example\`.

### In-product nudges
- New \`firstRunCompleted\` pref (default false). On first startup after install we surface a single toast pointing at the prefs pane via the existing managed-progress \`toast\` helper. The flag is also flipped on the first successful Test Connection — so a user who discovers prefs without the toast won't see it next time. Reset to defaults re-arms.
- New \`lastHealthResult\` pref (JSON string). The prefs pane now auto-runs a \`/health\` check when there's no saved result, and paints the saved one on subsequent opens with a "last checked YYYY-MM-DD HH:MM" stamp. Successful Test Connection clicks persist; returning users see immediate signal.

### Deliberate scope cut

Two acceptance-criteria items from #21 are handled in #22 (the chore bundle) to keep diffs independent and avoid file conflicts between simultaneously-open PRs:

- Node version pinning (\`engines.node\`, \`.nvmrc\`).
- \`.env.example\` \`KEY=value\` normalization.

## Test plan

- [ ] Fresh install: first startup shows the one-time onboarding toast ~2.5 seconds in; subsequent startups don't.
- [ ] Open prefs pane on a fresh install: auto-runs Test Connection and paints the result.
- [ ] Open prefs pane on a repeat visit: shows the previous result with a "last checked" timestamp.
- [ ] Successful Test Connection completes the nudge — restart Zotero and confirm the toast doesn't reappear.
- [ ] Reset to defaults re-arms both prefs.
- [ ] README renders correctly on GitHub.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)