### PR TITLE
Add first-class remote LLM API for picture description (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,53 @@ sections of the prefs UI itself. Hover any field for inline help.
 
 ---
 
+## Using a remote LLM for picture descriptions
+
+Instead of running a local picture-description model (`smolvlm`, `granite_vision`,
+…), you can point the plugin at an external Vision-Language Model API: Claude,
+GPT-4o, Llama 3.2 Vision via Ollama, anything on OpenRouter, a local LM Studio
+or vLLM server. Useful when you already have API credentials, want to skip
+gigabytes of local model downloads, or want to mix-and-match models per
+provider.
+
+### Server-side requirement
+
+`docling-serve` ignores the relevant form field by default. Start it with the
+remote-services opt-in:
+
+```bash
+DOCLING_SERVE_ENABLE_REMOTE_SERVICES=true docling-serve run
+```
+
+For the container image, pass `-e DOCLING_SERVE_ENABLE_REMOTE_SERVICES=true`.
+
+### Plugin configuration
+
+In **Settings → zotero-docling → Remote LLM API**:
+
+1. Tick **Use a remote LLM API for picture descriptions**.
+2. Pick a **Provider** — the URL and model fields prefill with sensible
+   defaults you can edit.
+3. Fill in your **API key** (left blank for Ollama / LM Studio / local vLLM).
+4. Optionally tweak the **Prompt**.
+5. Click **Test Remote API** to confirm the URL parses and the provider is
+   reachable.
+
+Picture description is forced on while this checkbox is ticked — the option
+only makes sense when there are figures to describe.
+
+### Provider notes
+
+- **OpenAI / OpenRouter / Ollama / LM Studio / vLLM**: all OpenAI-wire-compatible.
+- **Anthropic**: native API is not OpenAI-compatible at the wire level — the
+  preset shapes the request but you'll need an intermediary proxy (e.g.
+  `claude-relay`, LiteLLM) that translates `/v1/messages` to `/v1/chat/completions`.
+- **API key storage**: keys are stored in plain text in your Zotero profile.
+  Use a least-privilege key with usage caps. See [SECURITY.md](SECURITY.md) for
+  the full threat model.
+
+---
+
 ## Known limitations
 
 ### No cancel or async timeout for an in-flight conversion

--- a/addon/content/preferences.xhtml
+++ b/addon/content/preferences.xhtml
@@ -252,6 +252,110 @@
   </groupbox>
 
   <!-- ============================================================ -->
+  <!--  Remote LLM API (picture description via OpenAI / Ollama / …) -->
+  <!-- ============================================================ -->
+  <groupbox>
+    <label><html:h2 data-l10n-id="pref-remote-api-title"></html:h2></label>
+    <description data-l10n-id="pref-remote-api-help"></description>
+
+    <checkbox
+      id="zotero-docling-use-remote-api"
+      preference="useRemoteApi"
+      data-l10n-id="pref-use-remote-api"
+    />
+
+    <hbox align="center">
+      <html:label
+        data-l10n-id="pref-remote-api-provider"
+        style="min-width: 110px"
+      ></html:label>
+      <menulist
+        id="zotero-docling-remote-api-provider"
+        preference="remoteApiProvider"
+      >
+        <menupopup>
+          <menuitem value="openai" label="OpenAI" />
+          <menuitem value="anthropic" label="Anthropic" />
+          <menuitem value="ollama" label="Ollama (local)" />
+          <menuitem value="lmstudio" label="LM Studio (local)" />
+          <menuitem value="openrouter" label="OpenRouter" />
+          <menuitem value="vllm" label="vLLM" />
+          <menuitem value="custom" label="Custom" />
+        </menupopup>
+      </menulist>
+    </hbox>
+
+    <hbox align="center">
+      <html:label
+        for="zotero-docling-remote-api-url"
+        data-l10n-id="pref-remote-api-url"
+        style="min-width: 110px"
+      ></html:label>
+      <html:input
+        type="text"
+        id="zotero-docling-remote-api-url"
+        preference="remoteApiUrl"
+        style="flex: 1"
+      ></html:input>
+    </hbox>
+
+    <hbox align="center">
+      <html:label
+        for="zotero-docling-remote-api-model"
+        data-l10n-id="pref-remote-api-model"
+        style="min-width: 110px"
+      ></html:label>
+      <html:input
+        type="text"
+        id="zotero-docling-remote-api-model"
+        preference="remoteApiModel"
+        style="flex: 1"
+      ></html:input>
+    </hbox>
+
+    <hbox align="center">
+      <html:label
+        for="zotero-docling-remote-api-key"
+        data-l10n-id="pref-remote-api-key"
+        style="min-width: 110px"
+      ></html:label>
+      <html:input
+        type="password"
+        id="zotero-docling-remote-api-key"
+        preference="remoteApiKey"
+        style="flex: 1"
+      ></html:input>
+    </hbox>
+
+    <hbox align="start">
+      <html:label
+        for="zotero-docling-remote-api-prompt"
+        data-l10n-id="pref-remote-api-prompt"
+        style="min-width: 110px; padding-top: 0.4em"
+      ></html:label>
+      <html:textarea
+        id="zotero-docling-remote-api-prompt"
+        preference="remoteApiPrompt"
+        rows="3"
+        style="flex: 1; font-family: inherit"
+      ></html:textarea>
+    </hbox>
+
+    <hbox align="center">
+      <button
+        id="zotero-docling-test-remote-api"
+        data-l10n-id="pref-remote-api-test"
+        style="margin-left: 110px"
+      ></button>
+      <html:label
+        id="zotero-docling-remote-api-test-result"
+        style="margin-left: 1em; font-style: italic; min-height: 1.4em"
+      ></html:label>
+    </hbox>
+    <description data-l10n-id="pref-remote-api-security-note"></description>
+  </groupbox>
+
+  <!-- ============================================================ -->
   <!--  Async transport (Phase 4)                                    -->
   <!-- ============================================================ -->
   <groupbox>

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -53,6 +53,18 @@ pref-do-picture-desc =
 pref-pic-preset = Picture-description preset
 pref-preset-custom = Custom…
 
+pref-remote-api-title = Remote LLM API (picture description)
+pref-remote-api-help = Use an external Vision-Language Model API (OpenAI / Claude / Ollama / LM Studio / OpenRouter / vLLM) to describe figures in PDFs, instead of a local picture-description preset. Requires docling-serve to be started with DOCLING_SERVE_ENABLE_REMOTE_SERVICES=true. When this is enabled, "Describe pictures with a VLM" is forced on.
+pref-use-remote-api =
+    .label = Use a remote LLM API for picture descriptions
+pref-remote-api-provider = Provider
+pref-remote-api-url = API URL
+pref-remote-api-model = Model
+pref-remote-api-key = API key
+pref-remote-api-prompt = Prompt
+pref-remote-api-test = Test Remote API
+pref-remote-api-security-note = API key is stored unencrypted in your Zotero profile. Use a key with usage caps when possible. See SECURITY.md for the full threat model.
+
 pref-async-title = Async transport
 pref-async-help = Submit the job to docling-serve's async endpoint and poll for results. Recommended for long VLM conversions that would otherwise time out an upstream proxy. The sync endpoint is faster for short PDFs.
 pref-use-async =

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -46,3 +46,23 @@ pref("attachToItem", true);
 pref("exportFolderPath", "");
 // OS-level notification when a batch finishes, only if Zotero isn't focused.
 pref("notifyOnComplete", false);
+
+// Phase: Remote LLM API for picture description.
+//
+// When enabled, the plugin sends a `picture_description_api` JSON form field
+// to docling-serve instead of using the local `picture_description_preset`.
+// docling-serve must be started with DOCLING_SERVE_ENABLE_REMOTE_SERVICES=true
+// to honour this field — surfaced in the prefs pane help and README.
+//
+// API key is stored in plain text in the user's Zotero profile (see SECURITY.md).
+pref("useRemoteApi", false);
+// Provider preset — controls the default URL, model placeholder, and header
+// shape. "custom" leaves the fields free.
+pref("remoteApiProvider", "openai");
+pref("remoteApiUrl", "https://api.openai.com/v1/chat/completions");
+pref("remoteApiModel", "gpt-4o-mini");
+pref("remoteApiKey", "");
+pref(
+  "remoteApiPrompt",
+  "Describe this figure for an academic reader. Include axis labels, units, and any quantitative claims the figure is making.",
+);

--- a/src/modules/convert.ts
+++ b/src/modules/convert.ts
@@ -98,6 +98,58 @@ interface ConvertResponse {
 }
 
 /**
+ * Build the `picture_description_api` config object sent to docling-serve
+ * when the user has opted into a remote LLM for picture descriptions.
+ * Returns null when the configured fields are incomplete — the caller
+ * skips appending the form field in that case, so the conversion still
+ * runs (just without descriptions).
+ *
+ * Wire shape (sent JSON-stringified as a single multipart form field):
+ *   { url, headers, params: { model }, prompt, timeout }
+ *
+ * Anthropic's API is not OpenAI-wire-compatible; this function still
+ * shapes the request body, on the assumption that docling-serve or a
+ * proxy in front of it handles the translation. Surfaced in the prefs
+ * pane help text.
+ */
+export function buildPictureDescriptionApiConfig(): Record<
+  string,
+  unknown
+> | null {
+  const url = ((getPref("remoteApiUrl") as string) ?? "").trim();
+  if (!url) return null;
+  const model = ((getPref("remoteApiModel") as string) ?? "").trim();
+  const key = ((getPref("remoteApiKey") as string) ?? "").trim();
+  const prompt = ((getPref("remoteApiPrompt") as string) ?? "").trim();
+  const provider = ((getPref("remoteApiProvider") as string) ?? "custom")
+    .trim()
+    .toLowerCase();
+
+  // Provider determines the auth header shape. OpenAI-compatible providers
+  // (openai, ollama, lmstudio, openrouter, vllm) use Bearer. Anthropic uses
+  // x-api-key + the version pin. "custom" is permissive and skips auth if
+  // the user didn't supply a key.
+  const headers: Record<string, string> = {};
+  if (key) {
+    if (provider === "anthropic") {
+      headers["x-api-key"] = key;
+      headers["anthropic-version"] = "2023-06-01";
+    } else {
+      headers["Authorization"] = `Bearer ${key}`;
+    }
+  }
+
+  const config: Record<string, unknown> = { url };
+  if (Object.keys(headers).length > 0) config.headers = headers;
+  if (model) config.params = { model };
+  if (prompt) config.prompt = prompt;
+  // 300 s is what the docling-serve example payloads use; users with very
+  // slow models can override via Advanced JSON.
+  config.timeout = "300";
+  return config;
+}
+
+/**
  * Build the multipart body for POST /v1/convert/file by reading all relevant
  * prefs and turning them into flat form fields. The `advancedJson` pref is
  * merged last, so it overrides anything else.
@@ -146,12 +198,26 @@ function buildConvertForm(
   const vlmPreset = (getPref("vlmPreset") ?? "default") as string;
   if (vlmPreset) form.append("vlm_pipeline_preset", vlmPreset);
 
-  const doPicDesc = (getPref("doPictureDescription") ?? false) as boolean;
+  // Picture description: either a local preset OR a remote API. The remote
+  // API path requires docling-serve to be started with
+  // DOCLING_SERVE_ENABLE_REMOTE_SERVICES=true (surfaced in the prefs help).
+  const useRemoteApi = (getPref("useRemoteApi") ?? false) as boolean;
+  const doPicDescPref = (getPref("doPictureDescription") ?? false) as boolean;
+  // Enabling the remote API only makes sense if picture description is on;
+  // force it on so users don't have to flip two prefs to get descriptions.
+  const doPicDesc = useRemoteApi ? true : doPicDescPref;
   form.append("do_picture_description", String(doPicDesc));
   if (doPicDesc) {
-    const picPreset = (getPref("pictureDescriptionPreset") ??
-      "default") as string;
-    if (picPreset) form.append("picture_description_preset", picPreset);
+    if (useRemoteApi) {
+      const apiConfig = buildPictureDescriptionApiConfig();
+      if (apiConfig) {
+        form.append("picture_description_api", JSON.stringify(apiConfig));
+      }
+    } else {
+      const picPreset = (getPref("pictureDescriptionPreset") ??
+        "default") as string;
+      if (picPreset) form.append("picture_description_preset", picPreset);
+    }
   }
 
   // ocr_lang is a repeated field — server reads it as a list

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -4,8 +4,12 @@
 //   - Preset dropdowns "Custom…" entry → reveal a free-text input
 //   - "Reset to defaults" button → confirm + clear every plugin pref
 
-import { getPref } from "../utils/prefs";
-import { testServerConnection } from "./convert";
+import { getPref, setPref } from "../utils/prefs";
+import {
+  testServerConnection,
+  buildPictureDescriptionApiConfig,
+  getWebApis,
+} from "./convert";
 
 const LOG = "[zotero-docling]";
 
@@ -38,7 +42,48 @@ const ALL_PREF_KEYS: ReadonlyArray<string> = [
   "attachToItem",
   "exportFolderPath",
   "notifyOnComplete",
+  "useRemoteApi",
+  "remoteApiProvider",
+  "remoteApiUrl",
+  "remoteApiModel",
+  "remoteApiKey",
+  "remoteApiPrompt",
 ];
+
+/**
+ * Default URL + model for each provider preset. Switching the preset
+ * dropdown overwrites those two fields (and only those two) so a user
+ * can mix-and-match — e.g. point an "OpenAI" preset at an internal
+ * proxy that mirrors the OpenAI wire format.
+ */
+const PROVIDER_DEFAULTS: Record<string, { url: string; model: string }> = {
+  openai: {
+    url: "https://api.openai.com/v1/chat/completions",
+    model: "gpt-4o-mini",
+  },
+  anthropic: {
+    url: "https://api.anthropic.com/v1/messages",
+    model: "claude-sonnet-4-5",
+  },
+  ollama: {
+    url: "http://localhost:11434/v1/chat/completions",
+    model: "llama3.2-vision",
+  },
+  lmstudio: {
+    url: "http://localhost:1234/v1/chat/completions",
+    model: "",
+  },
+  openrouter: {
+    url: "https://openrouter.ai/api/v1/chat/completions",
+    model: "openrouter/auto",
+  },
+  vllm: {
+    url: "http://localhost:8000/v1/chat/completions",
+    model: "",
+  },
+  // "custom" is intentionally absent — switching to Custom leaves the
+  // existing fields alone so the user can edit freely.
+};
 
 export function registerPrefsScripts(win: Window): void {
   // Keep a handle to the prefs window in addon.data — the template's addon.ts
@@ -50,7 +95,110 @@ export function registerPrefsScripts(win: Window): void {
   bindPipelineToggle(win);
   bindPresetCustomToggle(win, "vlm");
   bindPresetCustomToggle(win, "pic");
+  bindRemoteApi(win);
   bindResetButton(win);
+}
+
+/**
+ * Wire the Remote LLM API section:
+ *   - Provider dropdown command listener overwrites url+model when changed
+ *     to a non-"custom" preset, so users get sensible defaults to edit.
+ *   - "Test Remote API" button validates the configured fields and runs a
+ *     cheap probe. We intentionally don't ship the API key off-machine
+ *     during the test beyond what a real conversion would do.
+ */
+function bindRemoteApi(win: Window): void {
+  const providerMenu = win.document.getElementById(
+    "zotero-docling-remote-api-provider",
+  ) as (HTMLElement & { value?: string }) | null;
+  const urlInput = win.document.getElementById(
+    "zotero-docling-remote-api-url",
+  ) as HTMLInputElement | null;
+  const modelInput = win.document.getElementById(
+    "zotero-docling-remote-api-model",
+  ) as HTMLInputElement | null;
+  const testBtn = win.document.getElementById(
+    "zotero-docling-test-remote-api",
+  ) as HTMLElement | null;
+  const testLabel = win.document.getElementById(
+    "zotero-docling-remote-api-test-result",
+  ) as HTMLElement | null;
+
+  if (providerMenu && urlInput && modelInput) {
+    providerMenu.addEventListener("command", () => {
+      const preset = (providerMenu.value as string) || "openai";
+      const defaults = PROVIDER_DEFAULTS[preset];
+      if (!defaults) return; // "custom" — leave fields alone
+      urlInput.value = defaults.url;
+      modelInput.value = defaults.model;
+      // The preference="" binding doesn't fire from a programmatic .value
+      // change in every Z9 build, so persist explicitly.
+      try {
+        setPref("remoteApiUrl", defaults.url);
+        setPref("remoteApiModel", defaults.model);
+      } catch {
+        /* ignore */
+      }
+    });
+  }
+
+  if (testBtn && testLabel) {
+    testBtn.addEventListener("command", async () => {
+      testLabel.textContent = "Testing…";
+      testLabel.style.color = "";
+      const cfg = buildPictureDescriptionApiConfig();
+      if (!cfg || typeof cfg.url !== "string" || !cfg.url) {
+        testLabel.textContent = "URL is required";
+        testLabel.style.color = "var(--accent-red, #c00)";
+        return;
+      }
+      let parsedUrl: URL;
+      try {
+        parsedUrl = new URL(cfg.url);
+      } catch {
+        testLabel.textContent = "URL doesn't parse (missing scheme?)";
+        testLabel.style.color = "var(--accent-red, #c00)";
+        return;
+      }
+      // Probe the provider's /models endpoint when the configured URL looks
+      // OpenAI-compatible (ends in /chat/completions). For other shapes we
+      // just confirm the URL parses and the model field isn't empty — a
+      // real conversion is the only way to validate further without
+      // burning API credits unexpectedly.
+      const headers = (cfg.headers as Record<string, string>) ?? {};
+      let api: ReturnType<typeof getWebApis>;
+      try {
+        api = getWebApis();
+      } catch (e) {
+        testLabel.textContent = `Cannot probe: ${(e as Error).message}`;
+        testLabel.style.color = "var(--accent-red, #c00)";
+        return;
+      }
+      if (parsedUrl.pathname.endsWith("/chat/completions")) {
+        const probeUrl = `${parsedUrl.origin}${parsedUrl.pathname.replace(/\/chat\/completions$/, "/models")}`;
+        try {
+          const r = await api.fetch(probeUrl, {
+            method: "GET",
+            headers,
+          });
+          if (r.ok) {
+            testLabel.textContent = `Reachable ✓ — ${probeUrl}`;
+            testLabel.style.color = "var(--accent-green, #2a8000)";
+          } else {
+            testLabel.textContent = `Probe failed — HTTP ${r.status} (URL parses, but credentials may be wrong)`;
+            testLabel.style.color = "var(--accent-red, #c00)";
+          }
+        } catch (e) {
+          testLabel.textContent = `Unreachable — ${(e as Error).message}`;
+          testLabel.style.color = "var(--accent-red, #c00)";
+        }
+      } else {
+        testLabel.textContent =
+          "URL parses ✓ (provider has no standard probe; a real conversion is the next step)";
+        testLabel.style.color = "var(--accent-green, #2a8000)";
+      }
+    });
+  }
 }
 
 /** "Test Connection" button → calls /health, paints status label. */

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -30,6 +30,12 @@ declare namespace _ZoteroTypes {
       "attachToItem": boolean;
       "exportFolderPath": string;
       "notifyOnComplete": boolean;
+      "useRemoteApi": boolean;
+      "remoteApiProvider": string;
+      "remoteApiUrl": string;
+      "remoteApiModel": string;
+      "remoteApiKey": string;
+      "remoteApiPrompt": string;
     };
   }
 }


### PR DESCRIPTION
## Summary

First-class support for sending figures to an external Vision-Language Model API (OpenAI, Anthropic, Ollama, LM Studio, OpenRouter, vLLM) for picture descriptions, replacing the Advanced-JSON workaround the README previously implied. Resolves #17.

### What the user sees

A new **Remote LLM API** section in preferences, beneath VLM and above Async transport:

- **Use a remote LLM API for picture descriptions** checkbox.
- **Provider** dropdown — 7 presets (OpenAI / Anthropic / Ollama / LM Studio / OpenRouter / vLLM / Custom). Switching to a non-Custom preset rewrites the URL and Model fields with sensible defaults.
- **API URL**, **Model**, **API key** (password-style), **Prompt** (multi-line, with an academic-figure default).
- **Test Remote API** button: probes `<origin>/models` for OpenAI-compatible providers; for Anthropic / non-standard shapes it just confirms the URL parses (avoids burning credits unexpectedly).
- Security note: "API key is stored unencrypted in your Zotero profile."

### Wire format

When the checkbox is on, `buildConvertForm`:

- Skips `picture_description_preset`.
- Forces `do_picture_description=true`.
- Appends `picture_description_api` as a JSON-stringified form field:
  ```json
  { "url": "...", "headers": {"Authorization": "Bearer ..."}, "params": {"model": "..."}, "prompt": "...", "timeout": "300" }
  ```
- Auth header shape switches by provider: `Bearer` for OpenAI-compatible, `x-api-key` + `anthropic-version: 2023-06-01` for Anthropic.

Advanced JSON still wins — anything set there overrides what this UI builds.

### Server-side requirement

This feature requires `docling-serve` to be started with `DOCLING_SERVE_ENABLE_REMOTE_SERVICES=true`. The plugin can't set it; it's a server env var. The README's new "Using a remote LLM" section documents this requirement clearly, and the in-prefs help text mentions it too.

### Out of scope (per the issue)

- LLM-based summarization, metadata extraction.
- OS-keyring secret storage.
- `vlm_pipeline_model_api` (the full-VLM-pipeline analogue) — deferred to Phase 2.

## Test plan

- [ ] Start `docling-serve` with `DOCLING_SERVE_ENABLE_REMOTE_SERVICES=true`. Configure the OpenAI preset with a valid key. Convert a PDF with a figure. Expect figure descriptions in the markdown.
- [ ] Switch to the Ollama preset. URL + model fields auto-fill. Test Remote API succeeds against a local Ollama with a vision model.
- [ ] Switch to Custom — fields stay alone (verify by inspection).
- [ ] Anthropic preset Test Remote API: gets the "URL parses" friendly message rather than 401 (it's not /chat/completions, so we don't probe).
- [ ] Disable the checkbox; conversion falls back to the local preset path with no behavioural change.
- [ ] Reset to defaults clears all new keys.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)