### PR TITLE
Add prefs-pane checkbox to re-enable Re-convert confirmation

### DIFF
--- a/addon/content/preferences.xhtml
+++ b/addon/content/preferences.xhtml
@@ -134,6 +134,11 @@
       preference="notifyOnComplete"
       data-l10n-id="pref-notify-on-complete"
     />
+    <checkbox
+      id="zotero-docling-confirm-reconvert"
+      preference="confirmReconvert"
+      data-l10n-id="pref-confirm-reconvert"
+    />
   </groupbox>
 
   <!-- ============================================================ -->

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -28,6 +28,8 @@ pref-max-concurrency = Parallel conversions
 pref-max-concurrency-help = How many PDFs to convert in parallel within one batch. Default 1 (sequential, safest). Higher values only speed things up when paired with the async endpoint AND a docling-serve started with --workers ≥ 2.
 pref-notify-on-complete =
     .label = OS notification when a batch finishes (only if Zotero isn't focused)
+pref-confirm-reconvert =
+    .label = Confirm before "Re-convert (replace)" deletes existing markdown
 
 pref-output-title = Output
 pref-attach-to-item =

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -42,6 +42,7 @@ export type FluentMessageId =
   | 'pref-auto-convert-help'
   | 'pref-behavior-title'
   | 'pref-build-info'
+  | 'pref-confirm-reconvert'
   | 'pref-conversion-title'
   | 'pref-disclosure-advanced-collapsed'
   | 'pref-disclosure-conversion-collapsed'


### PR DESCRIPTION
<!--
Thanks for the PR. Fill in the sections below — they help me review faster
and give an honest paper trail in the squashed commit message.

If this PR closes an issue, add "Closes #123" anywhere in the description.
-->

## Summary

Closes #34. Adds a single checkbox in the Behavior section of the preferences pane, bound to the existing `confirmReconvert` pref. This makes the opt-out/opt-back-in flow symmetrical with the in-dialog "Don't ask again" checkbox — previously, the only way to re-arm the confirmation was Reset to Defaults (which wipes every plugin pref).

## Changes

- `addon/content/preferences.xhtml` — new `<checkbox>` in the Behavior groupbox, right after the OS-notification checkbox, bound via `preference="confirmReconvert"`.
- `addon/locale/en-US/preferences.ftl` — new Fluent string `pref-confirm-reconvert`.
- `typings/i10n.d.ts` — regenerated by the build (one new entry).

## Test plan

- [x] `npm run lint:check` passes locally
- [x] `npm run build` produces an .xpi without errors
- [x] `npx tsc --noEmit` is clean
- [ ] Manually tested in a dev profile: open Settings → zotero-docling → Behavior; toggle the new checkbox; trigger Re-convert and verify confirmation dialog behavior matches the checkbox state. Also tick "Don't ask again" in the dialog and verify the checkbox unchecks on next prefs-pane open (state is the same pref).

## Notes for the reviewer

The pref, typing, and reset-to-defaults wiring all already exist from #26 — this PR is purely adding the UI affordance. Default behavior unchanged (`confirmReconvert` still defaults to `true` → checkbox checked → confirm dialog shown).

---

By submitting this PR I agree my contributions are licensed under
AGPL-3.0-or-later, matching the project licence.